### PR TITLE
エラーメッセージの表示

### DIFF
--- a/app/views/shared/_error_message.html.slim
+++ b/app/views/shared/_error_message.html.slim
@@ -1,0 +1,5 @@
+- if object.errors.any?
+  .alert.alert-danger
+    ul
+    - object.errors.full_messages.each do |message|
+      li = message

--- a/app/views/user_sessions/_form.html.slim
+++ b/app/views/user_sessions/_form.html.slim
@@ -1,6 +1,7 @@
 / （仮)とりあえず仮実装。もっときれいに整えること。CSSフレームワーク変えるかも。
 .container
   = form_with url: login_path, method: :post, local: true do |f|
+    = render 'shared/error_message', object: f.object
     .form-group
       = f.label :email, User.human_attribute_name(:email)
       = f.email_field :email, class: 'form-control'

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -2,6 +2,7 @@
 h1 ユーザー登録
 .container
   = form_with model: @user, local: true do |f|
+    = render 'shared/error_message', object: f.object
     .form-group
       = f.label :nickname
       = f.text_field :nickname, class: 'form-control'


### PR DESCRIPTION
## 概要
- ユーザー登録及びログインフォームの上部にバリデーションエラーを表示させるようにしました。

## コメント
暫定的に、ページ上部にエラーメッセージをまとめて表示していますが、今後はそれぞれのフォーム上部に表示させるように修正していきたいと思っています。
