### PR TITLE
CircleCIの導入

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,79 @@
+version: 2.1
+orbs:
+  ruby: circleci/ruby@0.1.2
+
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:2.7.2-node-browsers-legacy
+    executor: ruby/default
+    steps:
+      - checkout
+      - run:
+          name: Which bundler?
+          command: bundle -v
+      - ruby/bundle-install
+
+
+
+
+# # https://circleci.com/docs/2.0/language-ruby/#sample-configuration
+# version: 2.1
+# orbs:
+#   ruby: circleci/ruby@0.1.2
+# jobs:
+#   build:
+#     docker:
+#       - image: cimg/ruby:2.7.2-node-browsers-legacy
+#         environment:
+#           - BUNDER_VERSION: 2.1.4
+#           - RAILS_ENV: 'test'
+#       - image: circleci/mysql: 5.7
+#         environment:
+#           - MYSQL_ALLOW_EMPTY_PASSWORD: 'true'
+#           - MYSQL_ROOT_HOST: '%'
+#           - MYSQL_USER: root
+#           - MYSQL_DB: ci_test
+#     working_directory: ~/repo
+#     steps:
+#       - checkout # CI環境上の working_directory の値の場所にGitリポジトリをコピーする。
+
+#       # Restore bundle cache
+#       - restore_cache:
+#           keys:
+#             - rails-demo-{{ checksum "Gemfile.lock" }}
+#             - rails-demo-
+
+#       # Bundle install dependencies
+#       - run:
+#           name: Install dependencies
+#           command: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs 4 --retry 3
+
+#       - run: sudo apt install -y postgresql-client || true
+
+#       # Store bundle cache
+#       - save_cache:
+#           key: rails-demo-{{ checksum "Gemfile.lock" }}
+#           paths:
+#             - vendor/bundle
+
+#       - run:
+#           name: Database Setup
+#           command: |
+#             bundle exec rake db:create
+#             bundle exec rake db:structure:load
+
+#       - run:
+#           name: Parallel RSpec
+#           command: bin/rails test
+
+#       # Save artifacts
+#       - store_test_results:
+#           path: /tmp/test-results
+
+#       - run:
+#           name: Rubocop
+#           command: bundle exec rubocop
+#       - run:
+#           name: RSpec
+#           command: bundle exec rspec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,12 @@ jobs:
   build:
     docker:
       - image: circleci/ruby:2.7.2-node-browsers-legacy
+        environment:
+          - BUNDLER_VERSION: 2.1.4
+          - RAILS_ENV: 'test'
     executor: ruby/default
     steps:
-      - checkout
-      - run:
-          name: Which bundler?
-          command: bundle -v
-      - ruby/bundle-install
+      - run: echo 'HEllO World!'
 
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       # dockerコンテナの立ち上げを待つ
       - run:
           name: wait for database
-          command: dockerize -wait tcp://127.0.0.1:3306 -timeout 1m
+          command: dockerize -wait tcp://127.0.0.1:3306 -timeout 5m
 
       # キャッシュがあれば、リストアする。keysでリストアするキャッシュを複数指定
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,70 +9,63 @@ jobs:
         environment:
           - BUNDLER_VERSION: 2.1.4
           - RAILS_ENV: 'test'
-    executor: ruby/default
+          - DB_HOST: 127.0.0.1
+      - image: circleci/mysql:5.7
+        environment:
+          - MYSQL_ALLOW_EMPTY_PASSWORD: 'true'
+          - MYSQL_USER: root
+          - MYSQL_DB: ci_test
+    working_directory: ~/repo
     steps:
-      - run: echo 'HEllO World!'
+      # CI環境上の working_directory の値の場所にGitリポジトリをコピーする。
+      - checkout
 
+      # dockerコンテナの立ち上げを待つ
+      - run:
+          name: wait for database
+          command: dockerize -wait tcp://127.0.0.1:3306 -timeout 1m
 
+      # キャッシュがあれば、リストアする。keysでリストアするキャッシュを複数指定
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "Gemfile.lock" }}
+            - v1-dependencies-
 
+      # Bundle install dependencies
+      - run:
+          name: Install dependencies
+          command: |
+            gem install bundler -v 2.1.4
+            bundle install --path=vendor/bundle --jobs 4 --retry 3
 
-# # https://circleci.com/docs/2.0/language-ruby/#sample-configuration
-# version: 2.1
-# orbs:
-#   ruby: circleci/ruby@0.1.2
-# jobs:
-#   build:
-#     docker:
-#       - image: cimg/ruby:2.7.2-node-browsers-legacy
-#         environment:
-#           - BUNDER_VERSION: 2.1.4
-#           - RAILS_ENV: 'test'
-#       - image: circleci/mysql: 5.7
-#         environment:
-#           - MYSQL_ALLOW_EMPTY_PASSWORD: 'true'
-#           - MYSQL_ROOT_HOST: '%'
-#           - MYSQL_USER: root
-#           - MYSQL_DB: ci_test
-#     working_directory: ~/repo
-#     steps:
-#       - checkout # CI環境上の working_directory の値の場所にGitリポジトリをコピーする。
+      # キャッシュする
+      - save_cache:
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
 
-#       # Restore bundle cache
-#       - restore_cache:
-#           keys:
-#             - rails-demo-{{ checksum "Gemfile.lock" }}
-#             - rails-demo-
+      # DBのセットアップ
+      - run:
+          name: Database Setup
+          command: |
+            bundle exec rake db:create
+            bundle exec rake db:schema:load
 
-#       # Bundle install dependencies
-#       - run:
-#           name: Install dependencies
-#           command: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs 4 --retry 3
+      # rubocopを実行
+      - run:
+          name: Rubocop
+          command: bundle exec rubocop
 
-#       - run: sudo apt install -y postgresql-client || true
+      # RSpecを実行
+      - run:
+          name: Run rspec
+          command: |
+            bundle exec rspec --profile 10 \
+                              --format RspecJunitFormatter \
+                              --out test_results/rspec.xml \
+                              --format progress \
+                              $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
 
-#       # Store bundle cache
-#       - save_cache:
-#           key: rails-demo-{{ checksum "Gemfile.lock" }}
-#           paths:
-#             - vendor/bundle
-
-#       - run:
-#           name: Database Setup
-#           command: |
-#             bundle exec rake db:create
-#             bundle exec rake db:structure:load
-
-#       - run:
-#           name: Parallel RSpec
-#           command: bin/rails test
-
-#       # Save artifacts
-#       - store_test_results:
-#           path: /tmp/test-results
-
-#       - run:
-#           name: Rubocop
-#           command: bundle exec rubocop
-#       - run:
-#           name: RSpec
-#           command: bundle exec rspec
+      # Save artifacts
+      - store_test_results:
+          path: /tmp/test-results

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,9 @@ AllCops:
     - 'tmp/**/*'
     - 'spec/**/*'
     - 'node_modules/**/*'
+    - 'config/initializers/*'
   DisplayCopNames: true
+  TargetRubyVersion: 2.7.2
 
 Layout/MultilineBlockLayout:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,8 @@ end
 group :test do
   gem 'capybara'
   gem 'webdrivers'
+  # CircleCIで使用
+  gem 'rspec_junit_formatter'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,6 +238,8 @@ GEM
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
     rspec-support (3.10.0)
+    rspec_junit_formatter (0.4.1)
+      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (1.4.2)
       parallel (~> 1.10)
       parser (>= 2.7.1.5)
@@ -350,6 +352,7 @@ DEPENDENCIES
   rails-i18n (~> 6.0.0)
   rails_best_practices
   rspec-rails
+  rspec_junit_formatter
   rubocop
   rubocop-rails
   rubocop-rspec

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  skip_before_action :require_login, only: %i[index new create]
+  skip_before_action :require_login, only: %i[new create]
 
   def new
     @user = User.new

--- a/config/application.rb
+++ b/config/application.rb
@@ -48,6 +48,6 @@ module SharingKakeibo
 
     # 国際化対応/デフォルト言語の設定/読み込む対象のファイルを増やしている
     config.i18n.default_locale = :ja
-    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+    config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb,yml}').to_s]
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -28,6 +28,7 @@ development:
 test:
   <<: *default
   database: ci_test
+  host: <%=ENV['DB_HOST'] || '127.0.0.1' %>
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/config/database.yml
+++ b/config/database.yml
@@ -27,7 +27,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: Sharing_Kakeibo_test
+  database: ci_test
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp', 'caching-dev.txt').exist?
+  if Rails.root.join('tmp/caching-dev.txt').exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe User, type: :model do
   it 'nicknameがなかったら、ユーザー登録に失敗すること' do
     user = User.new(nickname: nil)
     user.valid?
-    expect(user.errors[:nickname]).to include("can't be blank")
+    expect(user.errors[:nickname]).to include("は1文字以上で入力してください")
   end
 
   it 'emailがなかったら、ユーザー登録に失敗すること' do
     user = User.new(email: nil)
     user.valid?
-    expect(user.errors[:email]).to include("can't be blank")
+    expect(user.errors[:email]).to include("を入力してください")
   end
 
   it '重複するemailの場合、ユーザー登録に失敗すること' do
@@ -28,20 +28,20 @@ RSpec.describe User, type: :model do
     user2 = build(:user)
     user2.email = user1.email
     user2.valid?
-    expect(user2.errors[:email]).to include("has already been taken")
+    expect(user2.errors[:email]).to include("はすでに存在します")
   end
 
   it 'パスワードが８文字以下の場合、ユーザー登録に失敗すること' do
     user = build(:user)
     user.password = 'p' * 7
     user.valid?
-    expect(user.errors[:password]).to include("is too short (minimum is 8 characters)")
+    expect(user.errors[:password]).to include("は8文字以上で入力してください")
   end
 
   it 'パスワードが１６文字以上の場合、ユーザー登録に失敗すること' do
     user = build(:user)
     user.password = 'p' * 17
     user.valid?
-    expect(user.errors[:password]).to include("is too long (maximum is 16 characters)")
+    expect(user.errors[:password]).to include("は16文字以内で入力してください")
   end
 end


### PR DESCRIPTION
close #10

## 概要
- `circleCI`を導入しました。  
- githubへ`push`すると同時に、`CircleCI`が起動し、`rubocop`でLintのチェック＆`RSpec`によるテストを自動で行います。

## 確認事項
- テスト用DB名を、`ci_test`に変更しましたので、`rails db:create`を実行してください。

## 参考にしたもの
[公式サンプルRuby用](https://circleci.com/docs/2.0/language-ruby/#sample-configuration)
[公式サンプルRails&Mysql用](https://circleci.com/docs/2.0/postgres-config/#example-circleci-configuration-for-a-rails-app-with-structuresql)
[bundler設定を参考](https://qiita.com/AK4747471/items/b2161784065f21cd1645)
[.circleci/config.yml内の用語参考](https://qiita.com/gold-kou/items/4c7e62434af455e977c2)


