### PR TITLE
Twitterアイコンを表示する

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -92,3 +92,7 @@ Metrics/MethodLength:
 
 Style/HashLikeCase:
   Enabled: false
+
+# Twitterプロフィール画像を取得するのに必要なため
+Security/Open:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'jbuilder', '~> 2.7'
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
-# gem 'image_processing', '~> 1.2'
+gem 'image_processing', '~> 1.2'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,8 @@ gem 'jbuilder', '~> 2.7'
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
-gem 'image_processing', '~> 1.2'
+# gem 'image_processing', '~> 1.2'
+# gem 'mini_magick'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,9 +130,6 @@ GEM
       hpricot
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
-    image_processing (1.12.1)
-      mini_magick (>= 4.9.5, < 5)
-      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.10.1)
       activesupport (>= 5.0.0)
     jquery-rails (4.4.0)
@@ -167,7 +164,6 @@ GEM
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
     mimemagic (0.3.5)
-    mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)
@@ -309,8 +305,6 @@ GEM
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.10.1)
-    ruby-vips (2.0.17)
-      ffi (~> 1.9)
     ruby2_keywords (0.0.2)
     rubyzip (2.3.0)
     sass-rails (6.0.0)
@@ -406,7 +400,6 @@ DEPENDENCIES
   foreman
   gretel
   html2slim
-  image_processing (~> 1.2)
   jbuilder (~> 2.7)
   kaminari
   listen (~> 3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,9 @@ GEM
       hpricot
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.1)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.10.1)
       activesupport (>= 5.0.0)
     jquery-rails (4.4.0)
@@ -164,6 +167,7 @@ GEM
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
     mimemagic (0.3.5)
+    mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)
@@ -305,6 +309,8 @@ GEM
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.10.1)
+    ruby-vips (2.0.17)
+      ffi (~> 1.9)
     ruby2_keywords (0.0.2)
     rubyzip (2.3.0)
     sass-rails (6.0.0)
@@ -400,6 +406,7 @@ DEPENDENCIES
   foreman
   gretel
   html2slim
+  image_processing (~> 1.2)
   jbuilder (~> 2.7)
   kaminari
   listen (~> 3.2)

--- a/app/controllers/account_books_controller.rb
+++ b/app/controllers/account_books_controller.rb
@@ -6,7 +6,7 @@ class AccountBooksController < ApplicationController
   def index
     @q = AccountBook.ransack(params[:q])
     @account_books = @q.result
-                       .includes([:likes, { user: [:user_profile, :avator_attachment] }])
+                       .includes([:likes, { user: %i[user_profile avator_attachment] }])
                        .order(created_at: :desc)
                        .page(params[:page])
   end

--- a/app/controllers/account_books_controller.rb
+++ b/app/controllers/account_books_controller.rb
@@ -6,7 +6,7 @@ class AccountBooksController < ApplicationController
   def index
     @q = AccountBook.ransack(params[:q])
     @account_books = @q.result
-                       .includes([:likes, { user: [:user_profile] }])
+                       .includes([:likes, { user: [:user_profile, :avator_attachment] }])
                        .order(created_at: :desc)
                        .page(params[:page])
   end

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -8,18 +8,19 @@ class OauthsController < ApplicationController
   def callback
     provider = params[:provider]
     # 認証をキャンセルしたときの処理
-    if params[:dinied].present?
+    if params[:denied].present?
       redirect_to root_path, info: 'ログインをキャンセルしました'
       return
     end
     if (@user = login_from(provider))
-      redirect_to root_path, success: "#{provider.titleize}でログインしました"
+      redirect_to account_books_path, success: "#{provider.titleize}でログインしました"
     else
       begin
         @user = create_from(provider)
+        @user.download_and_attach_profile_image(@user.profile_image)
         reset_session
         auto_login(@user)
-        redirect_to root_path, success: "#{provider.titleize}でログインしました"
+        redirect_to account_books_path, success: "#{provider.titleize}でログインしました"
       rescue StandardError
         redirect_to root_path, error: "#{provider.titleize}のログインに失敗しました"
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,10 @@
 class User < ApplicationRecord
   # httpでネットワーク上のリソースを取得
   require 'open-uri'
+
+  # twiiter画像をオリジナルサイズに加工
+  before_save { self.profile_image = profile_image&.gsub('_normal', '') }
+
   authenticates_with_sorcery!
   has_many :authentications, dependent: :destroy
   has_one :user_profile, dependent: :destroy
@@ -40,10 +44,10 @@ class User < ApplicationRecord
   def download_and_attach_profile_image(profile_image)
     return unless profile_image
 
-    profile_image = profile_image&.gsub(/_normal/, '')
     file = URI.open(profile_image)
-    avator.attach(io: file,
-                  filename: "profile_image.#{file.content_type_parse.first.split("/").last}",
-                  content_type: file.content_type_parse.first)
+    binding.pry
+    self.avator.attach(io: file,
+                       filename: "profile_image.#{file.content_type_parse.first.split("/").last}",
+                       content_type: file.content_type_parse.first)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,7 +45,6 @@ class User < ApplicationRecord
     return unless profile_image
 
     file = URI.open(profile_image)
-    binding.pry
     self.avator.attach(io: file,
                        filename: "profile_image.#{file.content_type_parse.first.split("/").last}",
                        content_type: file.content_type_parse.first)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,8 +45,8 @@ class User < ApplicationRecord
     return unless profile_image
 
     file = URI.open(profile_image)
-    self.avator.attach(io: file,
-                       filename: "profile_image.#{file.content_type_parse.first.split("/").last}",
-                       content_type: file.content_type_parse.first)
+    avator.attach(io: file,
+                  filename: "profile_image.#{file.content_type_parse.first.split('/').last}",
+                  content_type: file.content_type_parse.first)
   end
 end

--- a/app/views/account_books/_account_book.html.slim
+++ b/app/views/account_books/_account_book.html.slim
@@ -1,8 +1,11 @@
 .container.overflow-hidden.bg-beaver-50.rounded-3xl.text-gray-600.body-font.shadow-md.border-t-8.border-carrot-300.mb-5
   .flex.flex-wrap.items-center.justify-center.p-4.w-full
     div class="w-full py-1 px-2 mb-5 rounded text-gray-600 text-xl font-medium tracking-widest flex items-center flex-wrap justify-left"
-      <img src="https://dummyimage.com/104x104" class="w-12 h-12 rounded-full flex-shrink-0 object-cover object-center mr-3">
-      p #{account_book.user.nickname}さん
+      - if account_book.user.avator.attached?
+        = image_tag account_book.user.avator.variant(resize_to_limit:[70, 70])
+      - else
+        = image_pack_tag 'kakeibo_cat.png', size: '70x70'
+      p.ml-3 #{account_book.user.nickname}さん
       p.mt-3 #{l account_book.date, format: :short}の家計簿
     / = pie_chart account_book.order_by_expenses, library: {title: {text: "支出<br> #{number_to_currency(account_book.expenses.sum(:expenditure))}"}}
     = pie_chart account_book.expenses.order_by_expense_item_group,library: {title: {text: "支出<br> #{number_to_currency(account_book.expenses.sum(:expenditure))}"}}

--- a/app/views/account_books/_account_book.html.slim
+++ b/app/views/account_books/_account_book.html.slim
@@ -4,7 +4,7 @@
       - if account_book.user.avator.attached?
         = image_tag account_book.user.avator , size: '70x70', class:'rounded-full'
       - else
-        = image_pack_tag 'kakeibo_cat.png', size: '60x60'
+        = image_pack_tag 'kakeibo_cat.png', size: '70x70'
       p.ml-3 #{account_book.user.nickname}さん
       p.mt-3 #{l account_book.date, format: :short}の家計簿
     / = pie_chart account_book.order_by_expenses, library: {title: {text: "支出<br> #{number_to_currency(account_book.expenses.sum(:expenditure))}"}}

--- a/app/views/account_books/_account_book.html.slim
+++ b/app/views/account_books/_account_book.html.slim
@@ -2,9 +2,9 @@
   .flex.flex-wrap.items-center.justify-center.p-4.w-full
     div class="w-full py-1 px-2 mb-5 rounded text-gray-600 text-xl font-medium tracking-widest flex items-center flex-wrap justify-left"
       - if account_book.user.avator.attached?
-        = image_tag account_book.user.avator.variant(resize_to_limit:[70, 70])
+        = image_tag account_book.user.avator , size: '70x70', class:'rounded-full'
       - else
-        = image_pack_tag 'kakeibo_cat.png', size: '70x70'
+        = image_pack_tag 'kakeibo_cat.png', size: '60x60'
       p.ml-3 #{account_book.user.nickname}さん
       p.mt-3 #{l account_book.date, format: :short}の家計簿
     / = pie_chart account_book.order_by_expenses, library: {title: {text: "支出<br> #{number_to_currency(account_book.expenses.sum(:expenditure))}"}}

--- a/app/views/account_books/index.html.slim
+++ b/app/views/account_books/index.html.slim
@@ -2,7 +2,6 @@
 - breadcrumb :account_books
 .px-1
   .text-4xl.sm:text-3xl.text-center.my-10 みんなの家計簿
-  = image_pack_tag 'kakeibo_cat.png', size: '100x100'
   = render 'search_form', url: account_books_path, q: @q
   .grid.grid-cols-1.m-5.sm:grid-cols-1.md:grid-cols-2.xl:grid-cols-3.gap-4
     = render @account_books

--- a/app/views/account_books/show.html.slim
+++ b/app/views/account_books/show.html.slim
@@ -6,11 +6,13 @@ section.text-gray-600.body-font.overflow-hidden
       / 家計簿部分
       .p-12.md:w-1/2.flex.flex-col.items-start
         div class="w-full py-1 px-2 mb-5 rounded text-gray-600 text-xl font-medium tracking-widest flex items-center flex-wrap justify-left"
-          <img alt="blog" src="https://dummyimage.com/104x104" class="w-12 h-12 rounded-full flex-shrink-0 object-cover object-center mr-3">
+          - if @account_book.user.avator.attached?
+            = image_tag @account_book.user.avator.variant(resize_to_limit:[70, 70])
+          - else
+            = image_pack_tag 'kakeibo_cat.png', size: '70x70'
           p #{@account_book.user.nickname}さん
-          p.mt-3 #{l @account_book.date, format: :short}の家計簿
         .flex.items-center.flex-wrap.pb-4.mb-2.border-gray-100.mt-auto.w-full.justify-center
-          span class="inline-block py-1 px-2 mb-5 rounded text-carrot-600 text-xl font-medium tracking-widest" #{@account_book.user.nickname}さん #{l @account_book.date, format: :short}の家計簿
+          p.mt-3.inline-block.py-1.px-2.mb-5.rounded.text-carrot-600.text-xl.font-medium.tracking-widest #{l @account_book.date, format: :short}の家計簿
           = pie_chart @expenses,library: {title: {text: "支出<br> #{number_to_currency(@sum_of_expenditure)}"}}
           .items-right.w-full.text-right
             = render 'like_button', account_book: @account_book

--- a/app/views/account_books/show.html.slim
+++ b/app/views/account_books/show.html.slim
@@ -46,15 +46,18 @@ section.text-gray-600.body-font.overflow-hidden
       / プロフィール部分
       .p-12.md:w-1/2.flex.flex-col.items-start
         .flex.items-center.flex-wrap.pb-4.mb-2.border-gray-100.mt-auto.w-full.justify-center.tracking-wide
-          p.w-full.m-10 Twitterでシェア
-          span class="fa-stack fa-lg text-blue-500 items-center justify-center mr-3"
-            i class="fas fa-circle fa-stack-2x"
-            i class="fab fa-twitter fa-stack-1x text-white"
-          a class="inline-flex items-center"
-          <img alt="blog" src="https://dummyimage.com/104x104" class="w-12 h-12 rounded-full flex-shrink-0 object-cover object-center">
-          span class="flex-grow flex flex-col pl-4"
-            span class="title-font font-medium text-gray-900" #{@account_book.user.nickname}
-            span class="text-gray-400 text-xs tracking-widest mt-0.5" twitter-url
+          / p.w-full.m-10 Twitterでシェア
+          / span class="fa-stack fa-lg text-blue-500 items-center justify-center mr-3"
+          /   i class="fas fa-circle fa-stack-2x"
+          /   i class="fab fa-twitter fa-stack-1x text-white"
+        .flex.flex-col.pl-4.justify-left.w-full.text-lg.font-bold
+          - if @account_book.user.twitter_screen_name?
+            = link_to "https://twitter.com/#{@account_book.user.twitter_screen_name}" do
+              span class="fa-stack fa-lg text-blue-500 items-center"
+                i class="fas fa-circle fa-stack-2x"
+                i class="fab fa-twitter fa-stack-1x text-white"
+              | #{@account_book.user.nickname}さんのTwitter
+
           / プロフィールテーブル
           table.w-full.border-collapse.mt-4.break-all.whitespace-pre-wrap.table-fixed.tracking-wide
            tbody

--- a/app/views/account_books/show.html.slim
+++ b/app/views/account_books/show.html.slim
@@ -7,7 +7,7 @@ section.text-gray-600.body-font.overflow-hidden
       .p-12.md:w-1/2.flex.flex-col.items-start
         div class="w-full py-1 px-2 mb-5 rounded text-gray-600 text-xl font-medium tracking-widest flex items-center flex-wrap justify-left"
           - if @account_book.user.avator.attached?
-            = image_tag @account_book.user.avator.variant(resize_to_limit:[70, 70])
+            = image_tag @account_book.user.avator, size: '70x70', class:'rounded-full'
           - else
             = image_pack_tag 'kakeibo_cat.png', size: '70x70'
           p #{@account_book.user.nickname}さん

--- a/app/views/dashboards/show.html.slim
+++ b/app/views/dashboards/show.html.slim
@@ -1,4 +1,4 @@
-- breadcrumb :account_book
+- breadcrumb :dashboard
 = content_for(:title, t('.title'))
 section.text-gray-600.body-font.overflow-hidden
   .container.px-10.py-20.mx-auto
@@ -7,7 +7,7 @@ section.text-gray-600.body-font.overflow-hidden
       .p-12.md:w-1/2.flex.flex-col.items-start
         .flex.items-center.flex-wrap.pb-4.mb-2.border-gray-100.mt-auto.w-full.justify-center
           - if @account_book.user.avator.attached?
-            = image_tag @account_book.user.avator.variant(resize_to_limit:[70, 70])
+            = image_tag @account_book.user.avator.variant(resize_to_limit:[70, 70]).processed
           - else
             = image_pack_tag 'kakeibo_cat.png', size: '70x70'
           span class="inline-block py-1 px-2 mb-5 rounded text-carrot-600 text-xl font-medium tracking-widest" #{@account_book.user.nickname}さん #{l @account_book.date, format: :short}の家計簿

--- a/app/views/dashboards/show.html.slim
+++ b/app/views/dashboards/show.html.slim
@@ -7,7 +7,7 @@ section.text-gray-600.body-font.overflow-hidden
       .p-12.md:w-1/2.flex.flex-col.items-start
         .flex.items-center.flex-wrap.pb-4.mb-2.border-gray-100.mt-auto.w-full.justify-center
           - if @account_book.user.avator.attached?
-            = image_tag @account_book.user.avator.variant(resize_to_limit:[70, 70]).processed
+            = image_tag @account_book.user.avator , size: '70x70', class:'rounded-full'
           - else
             = image_pack_tag 'kakeibo_cat.png', size: '70x70'
           span class="inline-block py-1 px-2 mb-5 rounded text-carrot-600 text-xl font-medium tracking-widest" #{@account_book.user.nickname}さん #{l @account_book.date, format: :short}の家計簿

--- a/app/views/dashboards/show.html.slim
+++ b/app/views/dashboards/show.html.slim
@@ -41,12 +41,14 @@ section.text-gray-600.body-font.overflow-hidden
                   td.table-border.text-right = number_to_currency(expenditure)
       / プロフィール部分
       .p-12.md:w-1/2.flex.flex-col.items-start
-        .flex.items-center.flex-wrap.pb-4.mb-2.mt-auto.w-full.justify-center.tracking-wide
-          a class="inline-flex items-center"
-          <img alt="blog" src="https://dummyimage.com/104x104" class="w-12 h-12 rounded-full flex-shrink-0 object-cover object-center">
-          span class="flex-grow flex flex-col pl-4"
-            span class="title-font font-medium text-gray-900" #{@account_book.user.nickname}
-            span class="text-gray-400 text-xs tracking-widest mt-0.5" twitter-url
+        .flex.flex-col.pl-4.justify-left.w-full.text-lg.font-bold
+          - if @account_book.user.twitter_screen_name?
+            = link_to "https://twitter.com/#{@account_book.user.twitter_screen_name}" do
+              span class="fa-stack fa-lg text-blue-500 items-center"
+                i class="fas fa-circle fa-stack-2x"
+                i class="fab fa-twitter fa-stack-1x text-white"
+              | #{@account_book.user.nickname}さんのTwitter
+
           / プロフィールテーブル
           table.w-full.border-collapse.mt-4.break-all.whitespace-pre-wrap.table-fixed
            tbody

--- a/app/views/dashboards/show.html.slim
+++ b/app/views/dashboards/show.html.slim
@@ -6,6 +6,10 @@ section.text-gray-600.body-font.overflow-hidden
       / 家計簿部分
       .p-12.md:w-1/2.flex.flex-col.items-start
         .flex.items-center.flex-wrap.pb-4.mb-2.border-gray-100.mt-auto.w-full.justify-center
+          - if @account_book.user.avator.attached?
+            = image_tag @account_book.user.avator.variant(resize_to_limit:[70, 70])
+          - else
+            = image_pack_tag 'kakeibo_cat.png', size: '70x70'
           span class="inline-block py-1 px-2 mb-5 rounded text-carrot-600 text-xl font-medium tracking-widest" #{@account_book.user.nickname}さん #{l @account_book.date, format: :short}の家計簿
           = pie_chart @expenses,library: {title: {text: "支出<br> #{number_to_currency(@sum_of_expenditure)}"}}
           .items-right.w-full.text-right

--- a/app/views/user_sessions/_form.html.slim
+++ b/app/views/user_sessions/_form.html.slim
@@ -22,7 +22,7 @@
               path d=("M13 9l3 3m0 0l-3 3m3-3H8m13 0a9 9 0 11-18 0 9 9 0 0118 0z") /
     .relative.mt-10.h-px.bg-gray-300.mb-10
       .absolute.left-0.top-0.flex.justify-center.w-full.-mt-2
-        span.bg-beaver-50.px-4.text-gray-500.items-center または、Twitterで登録
+        span.bg-beaver-50.px-4.text-gray-500.items-center または、Twitterでログイン
     / Twitterログインリンク
     = link_to auth_at_provider_path(provider: :twitter) do
       button.relative.mt-6.w-full.blue-square-button

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -92,7 +92,7 @@ Rails.application.config.sorcery.configure do |config|
   # emailを登録していないユーザーのエラーを防ぐために,screen_nameを取得
   config.twitter.user_info_mapping = {
     nickname: 'name',
-    twitter_id: 'id',
+    twitter_screen_name: 'screen_name',
     email: 'screen_name',
     profile_image: 'profile_image_url_https'
   }

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -84,15 +84,16 @@ Rails.application.config.sorcery.configure do |config|
 
   # Twitter will not accept any requests nor redirect uri containing localhost,
   # Make sure you use 0.0.0.0:3000 to access your app in development
-  
+
   config.twitter.key = Rails.application.credentials.twitter[:key]
   config.twitter.secret = Rails.application.credentials.twitter[:secret_key]
   # いづれ、本番用と分けるので環境変数をセットする
   config.twitter.callback_url = "http://127.0.0.1:3000/oauth/callback?provider=twitter"
-  # emailを登録していないがいるとエラーになるので、idいれちゃった
+  # emailを登録していないユーザーのエラーを防ぐために,screen_nameを取得
   config.twitter.user_info_mapping = {
     nickname: 'name',
-    email: "id",
+    twitter_id: 'id',
+    email: 'screen_name',
     profile_image: 'profile_image_url_https'
   }
 

--- a/db/migrate/20210109045126_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20210109045126_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/migrate/20210109051517_add_column_to_users.rb
+++ b/db/migrate/20210109051517_add_column_to_users.rb
@@ -1,5 +1,5 @@
 class AddColumnToUsers < ActiveRecord::Migration[6.0]
   def change
-    add_column :users, :twitter_id, :string
+    add_column :users, :twitter_screen_name, :string
   end
 end

--- a/db/migrate/20210109051517_add_column_to_users.rb
+++ b/db/migrate/20210109051517_add_column_to_users.rb
@@ -1,0 +1,5 @@
+class AddColumnToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :twitter_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_08_100741) do
+ActiveRecord::Schema.define(version: 2021_01_09_045126) do
 
   create_table "account_books", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.date "date"
@@ -19,6 +19,27 @@ ActiveRecord::Schema.define(version: 2021_01_08_100741) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "likes_count"
     t.index ["user_id"], name: "index_account_books_on_user_id"
+  end
+
+  create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
   create_table "authentications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
@@ -86,6 +107,7 @@ ActiveRecord::Schema.define(version: 2021_01_08_100741) do
   end
 
   add_foreign_key "account_books", "users"
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "expenses", "account_books"
   add_foreign_key "expenses", "expense_items"
   add_foreign_key "likes", "account_books"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_09_045126) do
+ActiveRecord::Schema.define(version: 2021_01_09_051517) do
 
   create_table "account_books", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.date "date"
@@ -103,6 +103,7 @@ ActiveRecord::Schema.define(version: 2021_01_09_045126) do
     t.integer "role", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "twitter_id"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -103,7 +103,7 @@ ActiveRecord::Schema.define(version: 2021_01_09_051517) do
     t.integer "role", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "twitter_id"
+    t.string "twitter_screen_name"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
## 概要
- Twitterから`profile_image_url_https`を取得し、ActiveStorageへアタッチする設定を追加しました。
- `profile_image_url`をオリジナルサイズで取得するために、`before_save`のコールバックでurlを加工しています。
- Twitterから`screen_name`を取得し、プロフィール部分にTwitterへのリンクを設置しました。

## 確認方法
1. カラムを追加したので `bundle exec rails db:migrate` を実行してください

## コメント
- 画像の編集機能は実装していませんが、今後追加するかもしれません。

参考にしたもの
https://note.com/artefactnote/n/n792f9ff697d8
https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/user-profile-images-and-banners
https://railsguides.jp/active_storage_overview.html#%E3%82%BB%E3%83%83%E3%83%88%E3%82%A2%E3%83%83%E3%83%97
https://docs.ruby-lang.org/ja/latest/method/Kernel/m/open.html
https://docs.ruby-lang.org/ja/latest/library/open=2duri.html