### PR TITLE
N+1問題の解消

### DIFF
--- a/app/controllers/account_books_controller.rb
+++ b/app/controllers/account_books_controller.rb
@@ -15,8 +15,9 @@ class AccountBooksController < ApplicationController
   def index
     @q = AccountBook.ransack(params[:q])
     @account_books = @q.result.includes([{ user: %i[user_profile avator_attachment] }, :expenses, :likes])
-                              .order(created_at: :desc)
-                              .page(params[:page])
+                       .joins(:expenses)
+                       .order(created_at: :desc)
+                       .page(params[:page])
   end
 
   # my家計簿の表示

--- a/app/controllers/account_books_controller.rb
+++ b/app/controllers/account_books_controller.rb
@@ -3,21 +3,21 @@ class AccountBooksController < ApplicationController
 
   # expensesが余計なEager Loadingと怒られるのでとった。
   # グラフ部分が多分 N + 1
-  def index
-    @q = AccountBook.ransack(params[:q])
-    @account_books = @q.result
-                       .includes([:likes, { user: %i[user_profile avator_attachment] }])
-                       .order(created_at: :desc)
-                       .page(params[:page])
-  end
-
-  # 保留 likesとexpensesが余計なEager Loadingと怒られる。 ???
   # def index
   #   @q = AccountBook.ransack(params[:q])
-  #   @account_books = @q.result.includes([{ user: :user_profile }, :expenses, :likes])
-  #                      .joins([{ user: :user_profile }, :expenses])
+  #   @account_books = @q.result
+  #                      .includes([:likes, { user: %i[user_profile avator_attachment] }])
+  #                      .order(created_at: :desc)
   #                      .page(params[:page])
   # end
+
+  # 保留 likesとexpensesが余計なEager Loadingと怒られる。 ???
+  def index
+    @q = AccountBook.ransack(params[:q])
+    @account_books = @q.result.includes([{ user: %i[user_profile avator_attachment] }, :expenses, :likes])
+                              .order(created_at: :desc)
+                              .page(params[:page])
+  end
 
   # my家計簿の表示
   def show

--- a/app/models/account_book.rb
+++ b/app/models/account_book.rb
@@ -7,7 +7,7 @@ class AccountBook < ApplicationRecord
   validate :date_cannot_be_in_the_future
 
   # N+1対策 今後考える
-  scope :order_by_expenses, -> { joins({ expenses: :expense_item }).group(:name).order('sum_expenditure DESC').sum(:expenditure) }
+  scope :order_by_expenses, -> { joins({ expenses: :expense_item }).includes({ expenses: :expense_item }).group(:name).order('sum_expenditure DESC').sum(:expenditure) }
   # scope :order_by_expense_item_group, -> { includes(:expense_item).group(:name).order('sum_expenditure DESC').sum(:expenditure) }
 
   # 家計簿は未来日付はNG


### PR DESCRIPTION
### 質問内容・実現したいこと
- N+１問題を解消したいです。
- アプリの構造的にはRUNTEQの基礎編課題と同じで、家計簿部分のパーシャルをレンダリングして、家計簿を一覧を表示しています。その際に、N+1問題が起こっているのですが、解消できません。
- `gem 'bullet'`を導入していますが、これでは検出されないので、解決方法のヒントを頂きたいです。

### 現状発生している問題・エラーメッセージ
<img width="398" alt="Screen Shot 2021-01-12 at 9 37 53" src="https://user-images.githubusercontent.com/67212652/104254305-e144d680-54b9-11eb-9b03-7b2374c63af4.png">

こちらが問題が生じている箇所です。  
モデルの構造は、親(家計簿/account_books)ー子(支出/expesnes)ー孫(支出項目/expense_items)となっており、孫(支出項目名)でグループ＆子(各支出)の合計値を出して、その合計値が高い順に並べてドーナツグラフ上に表示＆支出全体の合計額をドーナツグラフ中心に描写しています。

#2 参考のER図

ターミナル
<img width="1203" alt="Screen Shot 2021-01-12 at 9 18 02" src="https://user-images.githubusercontent.com/67212652/104254189-9b880e00-54b9-11eb-9906-bb0b8dea669a.png">

### どの処理までうまく動いているのか
- 計算は合っており、表面的な挙動は問題ないのですが、関連テーブル(expenses)の該当カラムの各合計を計算してそれを表示する部分＆全体のexpense（支出)を出す部分でN+１になってしまいます。

### 該当のソースコード

```
# account_books_controller.rb
  # expensesが余計なEager Loadingと怒られるのでとった。
  # グラフ部分が多分 N + 1
  # def index
  #   @q = AccountBook.ransack(params[:q])
  #   @account_books = @q.result
  #                      .includes([:likes, { user: %i[user_profile avator_attachment] }])
  #                      .order(created_at: :desc)
  #                      .page(params[:page])
  # end
```
```
# models/account_book.rb
class AccountBook < ApplicationRecord
  belongs_to :user
  has_many :expenses, dependent: :destroy
  has_many :likes, dependent: :destroy
  accepts_nested_attributes_for :expenses, reject_if: :all_blank, allow_destroy: true
  validates :date, presence: true
  validate :date_cannot_be_in_the_future

(略)
end

```
```
# models/expense.rb
class Expense < ApplicationRecord
  belongs_to :account_book
  belongs_to :expense_item

(略)

  # 支出額合計をグループ化し、降順に
  scope :order_by_expense_item_group, -> { includes(:expense_item).group(:name).order('sum_expenditure DESC').sum(:expenditure) }
end
```
```
# models/expense_item.rb
class ExpenseItem < ApplicationRecord
  has_many :expenses

(略)
end
```
```
# views/account_books/index.html.slim
- set_meta_tags title: t('.title')
- breadcrumb :account_books
.px-1.text-gray-500
  .flex.flex-row.mx-auto.justify-center.mb-5
    = image_pack_tag 'logo-no-border.png', size: '200x200'
  .text-right
    = render 'search_form', url: account_books_path, q: @q
  .grid.grid-cols-1.mx-5.mb-5.sm:grid-cols-1.md:grid-cols-2.xl:grid-cols-3.gap-4
    = render @account_books
  .flex.justify-center
    = paginate(@account_books)
```
```
# views/account_books/_account_books.html.slim
(略)
    p.mb-2.text-lg #{l account_book.date, format: :short}の家計簿
    = pie_chart account_book.expenses.order_by_expense_item_group,library: {title: {text: "支出<br> #{number_to_currency(account_book.expenses.sum(:expenditure))}"}}
    .items-right.w-full.text-right
      = render 'like_button', account_book: account_book
(略)
```
### エラーから考えられる原因
`includes`だけでなく、`join`で結合する必要がある？

### 試したこと
- #86 bulletをインストールし今回の問題部分以外は解消しました。
- 先の項目で、`join`が必要なのかと考え、includesしたあとにjoinしましたが、挙動は変わりませんでした。
- また、`expenses`を`include`すると、bulletに怒られます。

```
# account_books_controller.rb
  def index
    @q = AccountBook.ransack(params[:q])
    @account_books = @q.result.includes([{ user: %i[user_profile avator_attachment] }, :expenses, :likes])
                              .joins(:expenses)
                              .order(created_at: :desc)
                              .page(params[:page])
  end
```
`includes + join`した後の挙動（むしろ悪化した)
<img width="1191" alt="Screen Shot 2021-01-12 at 10 01 47" src="https://user-images.githubusercontent.com/67212652/104255822-464dfb80-54bd-11eb-9a19-612dc026104a.png">

`expenses`を`include`すると、bulletに怒られる
<img width="881" alt="Screen Shot 2021-01-12 at 9 23 02" src="https://user-images.githubusercontent.com/67212652/104256155-fde30d80-54bd-11eb-99e9-e16c08223bd5.png">



### 参考にしたURL
https://techracho.bpsinc.jp/yusiro/2019_12_24/85407

